### PR TITLE
Fix escaping of < and > in code highlighting

### DIFF
--- a/app/utils/highlight.py
+++ b/app/utils/highlight.py
@@ -39,8 +39,8 @@ def highlight(html: str) -> str:
                 lexer = guess_lexer(code_content)
 
             # Replace the code with Pygment output
-            # XXX: the HTML escaping causes issue with Python type annotations
-            code_content = code_content.replace(") -&gt; ", ") -> ")
+            code_content = code_content.replace("&gt;", ">")
+            code_content = code_content.replace("&lt;", "<")
             code.parent.replaceWith(
                 BeautifulSoup(
                     phighlight(code_content, lexer, _FORMATTER), "html5lib"


### PR DESCRIPTION
Handles the < an > substitution with &lt; and &gt; in a more generic way. I tested this in my production instance and found no problems.

Upstream patch: https://lists.sr.ht/~tsileo/microblog.pub-devel/patches/40216