### PR TITLE
Fix bad URL string interpolation

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -61,7 +61,7 @@ async def user_session_or_redirect(
     _RedirectToLoginPage = HTTPException(
         status_code=302,
         headers={
-            "Location": request.url_for("login") + f"?redirect={quote(redirect_url)}"
+            "Location": str(request.url_for("login")) + f"?redirect={quote(redirect_url)}"
         },
     )
 


### PR DESCRIPTION
https://github.com/JD557/microblog.pub/pull/9 broke this line, as `request.url_for("login")` no longer had a `+` operation.