### PR TITLE
Convert redirect URL to string

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -54,7 +54,7 @@ async def user_session_or_redirect(
         if "redirect_url" in form_data:
             redirect_url = form_data["redirect_url"]
         else:
-            redirect_url = request.url_for("admin_stream")
+            redirect_url = str(request.url_for("admin_stream"))
     else:
         redirect_url = str(request.url)
 


### PR DESCRIPTION
Converts a missing redirect URL to string.
This is required for indieAuth authentication to work on som applications.

Upstream patch: https://lists.sr.ht/~tsileo/microblog.pub-devel/patches/43362