### PR TITLE
Add user recommendations to the lookup page

### DIFF
--- a/app/actor.py
+++ b/app/actor.py
@@ -291,6 +291,13 @@ async def fetch_actor(
     else:
         raise ap.ObjectNotFoundError(actor_id)
 
+async def list_actors(
+    db_session: AsyncSession,
+    limit: int = 100
+) -> list["ActorModel"]:
+    from app import models
+    return (await db_session.scalars(select(models.Actor).where(models.Actor.is_deleted.is_(False)).limit(limit))).unique().all()
+
 
 async def update_actor_if_needed(
     db_session: AsyncSession,

--- a/app/admin.py
+++ b/app/admin.py
@@ -25,6 +25,7 @@ from app import templates
 from app.actor import LOCAL_ACTOR
 from app.actor import fetch_actor
 from app.actor import get_actors_metadata
+from app.actor import list_actors
 from app.boxes import get_inbox_object_by_ap_id
 from app.boxes import get_outbox_object_by_ap_id
 from app.boxes import send_block
@@ -97,6 +98,7 @@ async def get_lookup(
     error = None
     ap_object = None
     actors_metadata = {}
+    actor_recommendations = await list_actors(db_session, 2500)
     if query:
         try:
             ap_object = await lookup(db_session, query)
@@ -152,6 +154,7 @@ async def get_lookup(
             "query": query,
             "ap_object": ap_object,
             "actors_metadata": actors_metadata,
+            "actor_recommendations": actor_recommendations,
             "error": error,
         },
     )

--- a/app/templates/lookup.html
+++ b/app/templates/lookup.html
@@ -11,8 +11,13 @@
     <p>Interact with an ActivityPub object via its URL or look for a user using <i>@user@domain.tld</i></p>
 
     <form class="form" action="{{ url_for("get_lookup") }}" method="GET">
-        <input type="text" name="query" value="{{ query if query else "" }}" autofocus>
+        <input type="text" list="actor-recommendations" name="query" value="{{ query if query else "" }}" autofocus>
         <input type="submit" value="Lookup">
+        <datalist id="actor-recommendations">
+            {% for actor in actor_recommendations %}
+            <option value="{{ actor.handle }}"></option>
+            {% endfor %}
+        </datalist>
     </form>
     </div>
 


### PR DESCRIPTION
Adds some autocomplete user recommendations to the lookup page.

Right now this is just recommending the first 2500 non-deleted users, although it might be worth to have a smarter heuristic in the future.