### PR TITLE
Skip attachments with no name

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -1168,7 +1168,7 @@ async def admin_actions_new(
     raw_form_data = await request.form()
     if len(files) >= 1:
         for f in files:
-            if f.filename is not None:
+            if f.filename is not None and f.filename is not "":
                 upload = await save_upload(db_session, f)
                 if upload is not None:
                     alt = raw_form_data.get("alt_" + f.filename)

--- a/app/admin.py
+++ b/app/admin.py
@@ -1168,7 +1168,7 @@ async def admin_actions_new(
     raw_form_data = await request.form()
     if len(files) >= 1:
         for f in files:
-            if f.filename is not None and f.filename is not "":
+            if f.filename is not None and f.filename != "":
                 upload = await save_upload(db_session, f)
                 if upload is not None:
                     alt = raw_form_data.get("alt_" + f.filename)


### PR DESCRIPTION
I think some dependency update broke this check.

This looks fine now.