### PR TITLE
Add pagination component

### DIFF
--- a/app/templates/admin_inbox.html
+++ b/app/templates/admin_inbox.html
@@ -1,4 +1,5 @@
 {%- import "utils.html" as utils with context -%}
+{%- import "components/pagination.html" as pagination -%}
 {% extends "layout.html" %}
 
 {% block head %}
@@ -48,10 +49,6 @@
 {% endif %}
 {% endfor %}
 
-{% if next_cursor %}
-<div class="box">
-    <p><a href="{{ request.url._path }}?cursor={{ next_cursor }}{% if request.query_params.filter_by %}&filter_by={{ request.query_params.filter_by }}{% endif %}">See more</a></p>
-</div>
-{% endif %}
+{{ pagination.pagination(request.url._path, next_cursor, request.query_params.filter_by) }}
 
 {% endblock %}

--- a/app/templates/admin_outbox.html
+++ b/app/templates/admin_outbox.html
@@ -1,4 +1,6 @@
+{%- import "components/pagination.html" as pagination -%}
 {%- import "utils.html" as utils with context -%}
+
 {% extends "layout.html" %}
 
 {% block head %}
@@ -37,10 +39,6 @@
 
 {% endfor %}
 
-{% if next_cursor %}
-<div class="box">
-    <p><a href="{{ url_for("admin_outbox") }}?cursor={{ next_cursor }}{% if request.query_params.filter_by %}&filter_by={{ request.query_params.filter_by }}{% endif %}">See more</a></p>
-</div>
-{% endif %}
+{{ pagination.pagination(url_for("admin_outbox"), next_cursor, request.query_params.filter_by) }}
 
 {% endblock %}

--- a/app/templates/components/pagination.html
+++ b/app/templates/components/pagination.html
@@ -1,0 +1,9 @@
+{% macro pagination(current_path, next_cursor=None, filter_by=None) %}
+{% block pagination scoped %}
+{% if next_cursor %}
+<div class="box">
+    <p><a href="{{ current_path }}?cursor={{ next_cursor }}{% if filter_by %}&filter_by={{ filter_by }}{% endif %}">See more</a></p>
+</div>
+{% endif %}
+{% endblock %}
+{% endmacro %}

--- a/app/templates/notifications.html
+++ b/app/templates/notifications.html
@@ -1,4 +1,5 @@
 {%- import "utils.html" as utils with context -%}
+{%- import "components/pagination.html" as pagination -%}
 {% extends "layout.html" %}
 
 {% block head %}
@@ -112,14 +113,6 @@
     {%- endfor %}
     </div>
 
-{% if next_cursor %}
-<div class="box">
-    <p>
-        <a href="{{ request.url._path }}?cursor={{ next_cursor }}">
-            See more{% if more_unread_count %} ({{ more_unread_count }} unread left){% endif %}
-        </a>
-    </p>
-</div>
-{% endif %}
+{{ pagination.pagination(request.url._path, next_cursor)}}
 
 {% endblock %}


### PR DESCRIPTION
Extracts the pagination logic of most admin pages into a pagination component.

Ideally, by moving common code to components like this, it will become more maintainable. Also, as long as those components don't require the global context, they should also be more efficient.