### PR TITLE
Fix actor variable shadowing

### DIFF
--- a/app/templates/admin_inbox.html
+++ b/app/templates/admin_inbox.html
@@ -1,5 +1,5 @@
 {%- import "utils.html" as utils with context -%}
-{%- import "components/actor.html" as actor -%}
+{%- import "components/actor.html" as actor_component -%}
 {%- import "components/filters.html" as filters -%}
 {%- import "components/pagination.html" as pagination -%}
 {% extends "layout.html" %}
@@ -24,7 +24,7 @@
 {% for inbox_object in inbox %}
 {% if inbox_object.ap_type == "Announce" %}
     <div class="h-entry" id="{{ inbox_object.permalink_id }}">
-        {{ actor.actor_action(url_for("admin_profile"), inbox_object, "shared", with_icon=True) }}
+        {{ actor_component.actor_action(url_for("admin_profile"), inbox_object, "shared", with_icon=True) }}
         <div class="h-cite u-repost-of">
             {{ utils.display_object(inbox_object.relates_to_anybox_object, is_h_entry=False) }}
         </div>
@@ -33,12 +33,12 @@
     {{ utils.display_object(inbox_object) }}
 {% elif inbox_object.ap_type == "Follow" %}
     <div class="h-entry" id="{{ inbox_object.permalink_id }}">
-        {{ actor.actor_action(url_for("admin_profile"), inbox_object, "followed you") }}
+        {{ actor_component.actor_action(url_for("admin_profile"), inbox_object, "followed you") }}
         {{ utils.display_actor(inbox_object.actor, actors_metadata, embedded=True) }}
     </div>
 {% elif inbox_object.ap_type == "Like" %}
     <div class="h-entry" id="{{ inbox_object.permalink_id }}">
-        {{ actor.actor_action(url_for("admin_profile"), inbox_object, "liked one of your posts", with_icon=True) }}
+        {{ actor_component.actor_action(url_for("admin_profile"), inbox_object, "liked one of your posts", with_icon=True) }}
         <div class="h-cite u-repost-of">
           {{ utils.display_object(inbox_object.relates_to_anybox_object, is_h_entry=False) }}
         </div>

--- a/app/templates/admin_profile.html
+++ b/app/templates/admin_profile.html
@@ -1,5 +1,5 @@
 {%- import "utils.html" as utils with context -%}
-{%- import "components/actor.html" as actor -%}
+{%- import "components/actor.html" as actor_component -%}
 
 {% block head %}
 <link rel="manifest" href="/static/pwa.webmanifest" />
@@ -12,7 +12,7 @@
     {% for inbox_object in inbox_objects %}
         {% if inbox_object.ap_type == "Announce" %}
             <div class="h-entry" id="{{ inbox_object.permalink_id }}">
-                {{ actor.actor_action(url_for("admin_profile"), inbox_object, "shared", with_icon=True) }}
+                {{ actor_component.actor_action(url_for("admin_profile"), inbox_object, "shared", with_icon=True) }}
                 <div class="h-cite u-repost-of">
                     {{ utils.display_object(inbox_object.relates_to_anybox_object, is_h_entry=False) }}
                 </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,5 +1,5 @@
 {%- import "utils.html" as utils with context -%}
-{%- import "components/actor.html" as actor -%}
+{%- import "components/actor.html" as actor_component -%}
 {% extends "layout.html" %}
 
 {% block head %}
@@ -31,7 +31,7 @@
     {{ utils.display_object(outbox_object) }}
     {% elif outbox_object.ap_type == "Announce" %}
     <div class="h-entry" id="{{ outbox_object.permalink_id }}">
-        <div class="shared-header"><strong><a class="p-author h-card" href="{{ local_actor.url }}">{{ actor.tiny_actor_icon(local_actor) }}  {{ local_actor.display_name | clean_html(local_actor) | safe }}</a></strong> shared <span title="{{ outbox_object.ap_published_at.isoformat() }}">{{ outbox_object.ap_published_at | timeago }}</span></div>
+        <div class="shared-header"><strong><a class="p-author h-card" href="{{ local_actor.url }}">{{ actor_component.tiny_actor_icon(local_actor) }}  {{ local_actor.display_name | clean_html(local_actor) | safe }}</a></strong> shared <span title="{{ outbox_object.ap_published_at.isoformat() }}">{{ outbox_object.ap_published_at | timeago }}</span></div>
         <div class="h-cite u-repost-of">
             {{ utils.display_object(outbox_object.relates_to_anybox_object, is_h_entry=False) }}
         </div>

--- a/app/templates/notifications.html
+++ b/app/templates/notifications.html
@@ -1,5 +1,5 @@
 {%- import "utils.html" as utils with context -%}
-{%- import "components/actor.html" as actor -%}
+{%- import "components/actor.html" as actor_component -%}
 {%- import "components/pagination.html" as pagination -%}
 {% extends "layout.html" %}
 
@@ -13,55 +13,55 @@
     <div>
         <div class="h-entry"">
             {%- if notif.notification_type.value == "new_follower" %}
-                {{ actor.actor_action(url_for("admin_profile"), notif, "followed you", new_flag=notif.is_new) }}
+                {{ actor_component.actor_action(url_for("admin_profile"), notif, "followed you", new_flag=notif.is_new) }}
                 {{ utils.display_actor(notif.actor, actors_metadata, embedded=True) }}
             {%- elif notif.notification_type.value == "pending_incoming_follower" %}
-                {{ actor.actor_action(url_for("admin_profile"), notif, "sent a follow request", new_flag=notif.is_new) }}
+                {{ actor_component.actor_action(url_for("admin_profile"), notif, "sent a follow request", new_flag=notif.is_new) }}
                 {{ utils.display_actor(notif.actor, actors_metadata, embedded=True, pending_incoming_follow_notif=notif) }}
             {% elif notif.notification_type.value == "rejected_follower" %}
             {% elif notif.notification_type.value == "unfollow" %}
-                {{ actor.actor_action(url_for("admin_profile"), notif, "unfollowed you", new_flag=notif.is_new) }}
+                {{ actor_component.actor_action(url_for("admin_profile"), notif, "unfollowed you", new_flag=notif.is_new) }}
                 {{ utils.display_actor(notif.actor, actors_metadata, embedded=True) }}
             {%- elif notif.notification_type.value == "follow_request_accepted" %}
-                {{ actor.actor_action(url_for("admin_profile"), notif, "accepted your follow request", new_flag=notif.is_new) }}
+                {{ actor_component.actor_action(url_for("admin_profile"), notif, "accepted your follow request", new_flag=notif.is_new) }}
                 {{ utils.display_actor(notif.actor, actors_metadata, embedded=True) }}
             {%- elif notif.notification_type.value == "follow_request_rejected" %}
-                {{ actor.actor_action(url_for("admin_profile"), notif, "rejected your follow request", new_flag=notif.is_new) }}
+                {{ actor_component.actor_action(url_for("admin_profile"), notif, "rejected your follow request", new_flag=notif.is_new) }}
                 {{ utils.display_actor(notif.actor, actors_metadata, embedded=True) }}
             {% elif notif.notification_type.value == "blocked" %}
-                {{ actor.actor_action(url_for("admin_profile"), notif, "blocked you", new_flag=notif.is_new) }}
+                {{ actor_component.actor_action(url_for("admin_profile"), notif, "blocked you", new_flag=notif.is_new) }}
                 {{ utils.display_actor(notif.actor, actors_metadata, embedded=True) }}
             {% elif notif.notification_type.value == "unblocked" %}
-                {{ actor.actor_action(url_for("admin_profile"), notif, "unblocked you", new_flag=notif.is_new) }}
+                {{ actor_component.actor_action(url_for("admin_profile"), notif, "unblocked you", new_flag=notif.is_new) }}
                 {{ utils.display_actor(notif.actor, actors_metadata, embedded=True) }}
             {% elif notif.notification_type.value == "block" %}
-                {{ actor.actor_action(url_for("admin_profile"), notif, "was blocked", new_flag=notif.is_new) }}
+                {{ actor_component.actor_action(url_for("admin_profile"), notif, "was blocked", new_flag=notif.is_new) }}
                 {{ utils.display_actor(notif.actor, actors_metadata, embedded=True) }}
             {% elif notif.notification_type.value == "unblock" %}
-                {{ actor.actor_action(url_for("admin_profile"), notif, "was unblocked", new_flag=notif.is_new) }}
+                {{ actor_component.actor_action(url_for("admin_profile"), notif, "was unblocked", new_flag=notif.is_new) }}
                 {{ utils.display_actor(notif.actor, actors_metadata, embedded=True) }}
             {%- elif notif.notification_type.value == "move" and notif.inbox_object %}
                 {# for move notif, the actor is the target and the inbox object the Move activity #}
                 <div class="actor-action">
                     <a href="{{ url_for("admin_profile") }}?actor_id={{ notif.inbox_object.actor.ap_id }}">
-                        {{ actor.tiny_actor_icon(notif.inbox_object.actor) }} {{ notif.inbox_object.actor.display_name | clean_html(notif.inbox_object.actor) | safe }}</a> has moved to
+                        {{ actor_component.tiny_actor_icon(notif.inbox_object.actor) }} {{ notif.inbox_object.actor.display_name | clean_html(notif.inbox_object.actor) | safe }}</a> has moved to
                     <span title="{{ notif.created_at.isoformat() }}">{{ notif.created_at | timeago }}</span>
                 </div>
                 {{ utils.display_actor(notif.actor) }}
             {% elif notif.notification_type.value == "like" %}
-                {{ actor.actor_action(url_for("admin_profile"), notif, "liked a post", with_icon=True, new_flag=notif.is_new) }}
+                {{ actor_component.actor_action(url_for("admin_profile"), notif, "liked a post", with_icon=True, new_flag=notif.is_new) }}
                 {{ utils.display_object(notif.outbox_object, is_h_entry=False) }}
            {% elif notif.notification_type.value == "undo_like" %}
-                {{ actor.actor_action(url_for("admin_profile"), notif, "unliked a post", with_icon=True, new_flag=notif.is_new) }}
+                {{ actor_component.actor_action(url_for("admin_profile"), notif, "unliked a post", with_icon=True, new_flag=notif.is_new) }}
                 {{ utils.display_object(notif.outbox_object, is_h_entry=False) }}
             {% elif notif.notification_type.value == "announce" %}
-                {{ actor.actor_action(url_for("admin_profile"), notif, "shared a post", with_icon=True, new_flag=notif.is_new) }}
+                {{ actor_component.actor_action(url_for("admin_profile"), notif, "shared a post", with_icon=True, new_flag=notif.is_new) }}
                 {{ utils.display_object(notif.outbox_object, is_h_entry=False) }}
            {% elif notif.notification_type.value == "undo_announce" %}
-                {{ actor.actor_action(url_for("admin_profile"), notif, "unshared a post", with_icon=True, new_flag=notif.is_new) }}
+                {{ actor_component.actor_action(url_for("admin_profile"), notif, "unshared a post", with_icon=True, new_flag=notif.is_new) }}
                 {{ utils.display_object(notif.outbox_object, is_h_entry=False) }}
             {% elif notif.notification_type.value == "mention" %}
-                {{ actor.actor_action(url_for("admin_profile"), notif, "mentioned you", new_flag=notif.is_new) }}
+                {{ actor_component.actor_action(url_for("admin_profile"), notif, "mentioned you", new_flag=notif.is_new) }}
                 {{ utils.display_object(notif.inbox_object, is_h_entry=False) }}
             {% elif notif.notification_type.value == "new_webmention" %}
                 <div class="actor-action" title="{{ notif.created_at.isoformat() }}">


### PR DESCRIPTION
Looks like in Jinja2 macro arguments are shadowed by context variables 🙃 

I guess this is another reason to not use `with context`.