### PR TITLE
Remove blocks from components

### DIFF
--- a/app/templates/components/actor.html
+++ b/app/templates/components/actor.html
@@ -1,11 +1,8 @@
 {% macro tiny_actor_icon(actor) %}
-{% block tiny_actor_icon scoped %}
     <img class="tiny-actor-icon" src="{{ actor.resized_icon_url }}" alt="" loading="lazy">
-{% endblock %}
 {% endmacro %}
 
 {% macro actor_action(admin_profile_url, inbox_object, text, with_icon=False, new_flag=False) %}
-{% block actor_action scoped %}
 {% set timestamp = inbox_object.ap_published_at %}
 {% if not timestamp %}
   {% set timestamp = inbox_object.created_at %}
@@ -19,5 +16,4 @@
             <span class="new">new</span>
         {% endif %}
     </div>
-{% endblock %}
 {% endmacro %}

--- a/app/templates/components/filters.html
+++ b/app/templates/components/filters.html
@@ -1,5 +1,4 @@
 {% macro filters(current_path, filter_by=None) %}
-{% block filters scoped %}
 <nav class="flexbox box">
 <ul>
     <li>Filter by</li>
@@ -16,5 +15,4 @@
 {% endif %}
 </ul>
 </nav>
-{% endblock %}
 {% endmacro %}

--- a/app/templates/components/pagination.html
+++ b/app/templates/components/pagination.html
@@ -1,9 +1,7 @@
 {% macro pagination(current_path, next_cursor=None, filter_by=None) %}
-{% block pagination scoped %}
 {% if next_cursor %}
 <div class="box">
     <p><a href="{{ current_path }}?cursor={{ next_cursor }}{% if filter_by %}&filter_by={{ filter_by }}{% endif %}">See more</a></p>
 </div>
 {% endif %}
-{% endblock %}
 {% endmacro %}


### PR DESCRIPTION
I'm not entirely sure why this was used. Looking at the [Jinja2 documentation](https://jinja.palletsprojects.com/en/2.10.x/templates/#template-inheritance), I can only assume this was used before the macros and the code just stayed there.

I'll be removing the blocks from now on when creating new components.