### PR TITLE
Fix constant clash on new post creation

### DIFF
--- a/app/static/new.js
+++ b/app/static/new.js
@@ -51,6 +51,5 @@ files.addEventListener("change", function(e) {
     }
 });
 // Focus at the end of the textarea
-const end = ta.value.length;
-ta.setSelectionRange(end, end);
+ta.setSelectionRange(ta.value.length, ta.value.length);
 ta.focus();


### PR DESCRIPTION
Follow up to #55.

Loading the New page twice was redeclaring `end` twice.