### PR TITLE
Add profile redirect

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -284,6 +284,7 @@ async def redirect_to_remote_instance(
 
 
 @app.get(config.NavBarItems.NOTES_PATH, response_model=None)
+@app.get("/@" + USERNAME, response_model=None)
 async def index(
     request: Request,
     db_session: AsyncSession = Depends(get_db_session),


### PR DESCRIPTION
Adds an extra endpoint to the index, so that requests like `https://blog.joaocosta.eu/@JD557` also show the notes.

This helps a bit to integrate with software that converts full usernames into URIs without checking webfinger (e.g. itch.io).

Currently this is case sensitive.