### PR TITLE
Fix bottlenecks in incoming activities queue

### DIFF
--- a/alembic/versions/2024_12_08_1122-aa8e72de7bb6_create_index_for_incoming_activity_next_.py
+++ b/alembic/versions/2024_12_08_1122-aa8e72de7bb6_create_index_for_incoming_activity_next_.py
@@ -1,0 +1,28 @@
+"""create index for incoming activity next try
+
+Revision ID: aa8e72de7bb6
+Revises: a209f0333f5a
+Create Date: 2024-12-09 11:22:57.917748+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'aa8e72de7bb6'
+down_revision = 'a209f0333f5a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('incoming_activity', schema=None) as batch_op:
+        batch_op.create_index(batch_op.f('ix_incoming_activity_next_try'), ['next_try'], unique=False)
+        batch_op.create_index(batch_op.f('ix_incoming_activity_status'), ['is_processed', 'is_errored'], unique=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('incoming_activity', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_incoming_activity_next_try'))
+        batch_op.drop_index(batch_op.f('ix_incoming_status'))

--- a/alembic/versions/2025_01_10_2021-49774a0f5911_unpack_ap_in_reply_to.py
+++ b/alembic/versions/2025_01_10_2021-49774a0f5911_unpack_ap_in_reply_to.py
@@ -1,0 +1,39 @@
+"""unpack ap_in_reply_to
+
+Revision ID: 49774a0f5911
+Revises: aa8e72de7bb6
+Create Date: 2025-01-10 12:21:31.055099+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '49774a0f5911'
+down_revision = 'aa8e72de7bb6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('inbox', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('in_reply_to', sa.Integer()))
+        batch_op.create_index(batch_op.f('ix_inbox_in_reply_to'), ['in_reply_to'], unique=False)
+
+    with op.batch_alter_table('outbox', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('in_reply_to', sa.Integer()))
+        batch_op.create_index(batch_op.f('ix_outbox_in_reply_to'), ['in_reply_to'], unique=False)
+
+    op.execute("UPDATE inbox SET in_reply_to = json_extract(ap_object, '$.inReplyTo')")
+    op.execute("UPDATE outbox SET in_reply_to = json_extract(ap_object, '$.inReplyTo')")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('inbox', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_inbox_in_reply_to'))
+        batch_op.drop_column('in_reply_to')
+
+    with op.batch_alter_table('outbox', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_outbox_in_reply_to'))
+        batch_op.drop_column('in_reply_to')

--- a/app/ap_object.py
+++ b/app/ap_object.py
@@ -212,10 +212,6 @@ class Object:
         return None
 
     @property
-    def in_reply_to(self) -> str | None:
-        return self.ap_object.get("inReplyTo")
-
-    @property
     def is_local_reply(self) -> bool:
         if not self.in_reply_to:
             return False
@@ -349,3 +345,7 @@ class RemoteObject(Object):
     @property
     def actor(self) -> Actor:
         return self._actor
+
+    @property
+    def in_reply_to(self) -> str | None:
+        return self._raw_object.get("inReplyTo")

--- a/app/models.py
+++ b/app/models.py
@@ -131,6 +131,7 @@ class InboxObject(Base, BaseObject):
     is_deleted = Column(Boolean, nullable=False, default=False)
     is_transient = Column(Boolean, nullable=False, default=False, server_default="0")
 
+    in_reply_to: Mapped[str] = Column(String, index=True)
     replies_count: Mapped[int] = Column(Integer, nullable=False, default=0)
 
     og_meta: Mapped[list[dict[str, Any]] | None] = Column(JSON, nullable=True)
@@ -179,6 +180,7 @@ class OutboxObject(Base, BaseObject):
     ap_published_at = Column(DateTime(timezone=True), nullable=False, default=now)
     visibility = Column(Enum(ap.VisibilityEnum), nullable=False)
     conversation = Column(String, nullable=True)
+    in_reply_to: Mapped[str] = Column(String, index=True)
 
     likes_count = Column(Integer, nullable=False, default=0)
     announces_count = Column(Integer, nullable=False, default=0)


### PR DESCRIPTION
Until recently I was running a highly customised and experimental fork of microblog.pub, but I got tired of it and decided to get back to the more stable original version. I ended up using your fork because it's more up to date in its maintenance.

From my fork I did recover this significant performance improvement, which you might find useful too.

Using py-spy I found that the biggest bottleneck was updating reply counters whenever a Delete activity came in (of which there are lots). This improves drastically when `inReplyTo` is stored in a dedicated column, rather than relying on SQLite's `json_extract` for this.

I also added two missing indices on the `incoming_activity` table.